### PR TITLE
Prometheus metrics

### DIFF
--- a/helm/resilient-splunk-forwarder/templates/service-monitor.yaml
+++ b/helm/resilient-splunk-forwarder/templates/service-monitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    component: {{ .Values.service.name }}
+    prometheus: {{ .Values.metrics.prometheusInstance }}
+  name: {{ .Values.service.name }}
+spec:
+  endpoints:
+  - interval: {{ .Values.metrics.interval }}
+    path: {{ .Values.metrics.path }}
+  jobLabel: component
+  selector:
+    matchLabels:
+      app: {{ .Values.service.name }}

--- a/helm/resilient-splunk-forwarder/values.yaml
+++ b/helm/resilient-splunk-forwarder/values.yaml
@@ -22,7 +22,7 @@ metrics:
   # where we expose the metrics for prometheus
   path: /metrics
   # how often prometheus will call the metrics path
-  interval: 5s
+  interval: 15s
   # the name of the prometheus instance, as defined in
   # content-k8s-prometheus\helm\content-k8s-prometheus\app-configs\monitoring-metrics_{env}.yaml
   prometheusInstance: monitoring-metrics

--- a/helm/resilient-splunk-forwarder/values.yaml
+++ b/helm/resilient-splunk-forwarder/values.yaml
@@ -18,3 +18,11 @@ env:
   WORKERS: "20"
   CHAN_BUFFER: "256"
   GRAPHITE_SERVER: "graphite.ft.com:2003"
+metrics:
+  # where we expose the metrics for prometheus
+  path: /metrics
+  # how often prometheus will call the metrics path
+  interval: 5s
+  # the name of the prometheus instance, as defined in
+  # content-k8s-prometheus\helm\content-k8s-prometheus\app-configs\monitoring-metrics_{env}.yaml
+  prometheusInstance: monitoring-metrics

--- a/main.go
+++ b/main.go
@@ -161,9 +161,9 @@ func initApp() *cli.Cli {
 		defer logrus.Printf("Resilient Splunk forwarder: Stopped\n")
 
 		s3, _ := NewS3Service(config.bucket, config.awsRegion, config.env)
+		envLabel = prometheus.Labels{"environment": config.env}
 		splunkForwarder := NewSplunkForwarder(config)
 		logProcessor := NewLogProcessor(splunkForwarder, s3, config)
-		envLabel = prometheus.Labels{"environment": config.env}
 
 		logProcessor.Start()
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 
 	health "github.com/Financial-Times/go-fthealth/v1_1"
 	status "github.com/Financial-Times/service-status-go/httphandlers"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const appDescription = "Forwards logs cached in S3 to Splunk"
@@ -213,6 +214,7 @@ func serveEndpoints(healthService *healthService, appSystemCode string, appName 
 	serveMux.HandleFunc(healthPath, health.Handler(hc))
 	serveMux.HandleFunc(status.GTGPath, status.NewGoodToGoHandler(healthService.GTG))
 	serveMux.HandleFunc(status.BuildInfoPath, status.BuildInfoHandler)
+	serveMux.Handle("/metrics", promhttp.Handler())
 
 	server := &http.Server{Addr: ":" + port, Handler: serveMux}
 

--- a/main.go
+++ b/main.go
@@ -18,11 +18,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-const appDescription = "Forwards logs cached in S3 to Splunk"
-
 const (
-	namespace = "upp"
-	subsystem = "splunk_forwarder"
+	namespace      = "upp"
+	subsystem      = "splunk_forwarder"
+	appDescription = "Forwards logs cached in S3 to Splunk"
 )
 
 var labelNames = []string{"environment"}
@@ -300,8 +299,7 @@ func registerHistogram(name, help string, buckets []float64) prometheus.Observer
 			Help:      help,
 			Buckets:   buckets,
 		},
-		labelNames,
-	)
+		labelNames)
 	prometheus.Register(h)
 	if envLabel == nil {
 		envLabel = prometheus.Labels{"environment": "dummy"}

--- a/main.go
+++ b/main.go
@@ -24,8 +24,10 @@ const (
 	appDescription = "Forwards logs cached in S3 to Splunk"
 )
 
-var labelNames = []string{"environment"}
-var envLabel prometheus.Labels
+var (
+	labelNames = []string{"environment"}
+	envLabel   prometheus.Labels
+)
 
 type appConfig struct {
 	appSystemCode  string

--- a/processor.go
+++ b/processor.go
@@ -50,7 +50,7 @@ func NewLogProcessor(forwarder Forwarder, cache Cache, config appConfig) LogProc
 			Subsystem: "splunk_forwarder",
 			Name:      "queue_latency",
 			Help:      "Post queue latency",
-			Buckets:   []float64{.000005, .00001, .000015, .00002, .000025, .00003, .00004, .00005},
+			Buckets:   []float64{.00001, .000015, .00002, .000025, .00003, .00004, .00005, .00006},
 		},
 		[]string{"environment"},
 	)

--- a/processor.go
+++ b/processor.go
@@ -54,6 +54,7 @@ func NewLogProcessor(forwarder Forwarder, cache Cache, config appConfig) LogProc
 		[]string{"environment"},
 	)
 
+	prometheus.Register(ql)
 	queueLatency = ql.With(prometheus.Labels{"environment": config.env})
 	return &logProcessor{forwarder: forwarder, cache: cache, wg: sync.WaitGroup{}, chanBuffer: config.chanBuffer, workers: config.workers}
 }

--- a/processor.go
+++ b/processor.go
@@ -44,13 +44,13 @@ var (
 )
 
 func NewLogProcessor(forwarder Forwarder, cache Cache, config appConfig) LogProcessor {
-	ql := prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Namespace:  "upp",
-			Subsystem:  "splunk_forwarder",
-			Name:       "queue_latency",
-			Help:       "Post queue latency",
-			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	ql := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "upp",
+			Subsystem: "splunk_forwarder",
+			Name:      "queue_latency",
+			Help:      "Post queue latency",
+			Buckets:   prometheus.DefBuckets,
 		},
 		[]string{"environment"},
 	)
@@ -129,10 +129,7 @@ func (logProcessor *logProcessor) Start() {
 					time.Sleep(sleepDuration)
 				}
 				t := metrics.GetOrRegisterTimer("post.queue.latency", metrics.DefaultRegistry)
-				prometheusTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-					us := v * 1000000 // make microseconds
-					queueLatency.Observe(us)
-				}))
+				prometheusTimer := prometheus.NewTimer(queueLatency)
 				t.Time(func() {
 					log.Printf("Sending document to channel")
 					logProcessor.outChan <- entry

--- a/processor.go
+++ b/processor.go
@@ -42,7 +42,7 @@ type logProcessor struct {
 var queueLatency prometheus.Observer
 
 func NewLogProcessor(forwarder Forwarder, cache Cache, config appConfig) LogProcessor {
-	if queueLatency != nil {
+	if queueLatency == nil {
 		queueLatency = registerHistogram("queue_latency", "Post queue latency", []float64{.00001, .000015, .00002, .000025, .00003, .00004, .00005, .00006})
 	}
 	return &logProcessor{forwarder: forwarder, cache: cache, wg: sync.WaitGroup{}, chanBuffer: config.chanBuffer, workers: config.workers}

--- a/processor.go
+++ b/processor.go
@@ -50,7 +50,7 @@ func NewLogProcessor(forwarder Forwarder, cache Cache, config appConfig) LogProc
 			Subsystem: "splunk_forwarder",
 			Name:      "queue_latency",
 			Help:      "Post queue latency",
-			Buckets:   prometheus.DefBuckets,
+			Buckets:   []float64{.000005, .00001, .000015, .00002, .000025, .00003, .00004, .00005},
 		},
 		[]string{"environment"},
 	)

--- a/processor.go
+++ b/processor.go
@@ -39,9 +39,7 @@ type logProcessor struct {
 	workers    int
 }
 
-var (
-	queueLatency prometheus.Observer
-)
+var queueLatency prometheus.Observer
 
 func NewLogProcessor(forwarder Forwarder, cache Cache, config appConfig) LogProcessor {
 	queueLatency = registerHistogram("queue_latency", "Post queue latency", []float64{.00001, .000015, .00002, .000025, .00003, .00004, .00005, .00006})

--- a/processor.go
+++ b/processor.go
@@ -42,7 +42,9 @@ type logProcessor struct {
 var queueLatency prometheus.Observer
 
 func NewLogProcessor(forwarder Forwarder, cache Cache, config appConfig) LogProcessor {
-	queueLatency = registerHistogram("queue_latency", "Post queue latency", []float64{.00001, .000015, .00002, .000025, .00003, .00004, .00005, .00006})
+	if queueLatency != nil {
+		queueLatency = registerHistogram("queue_latency", "Post queue latency", []float64{.00001, .000015, .00002, .000025, .00003, .00004, .00005, .00006})
+	}
 	return &logProcessor{forwarder: forwarder, cache: cache, wg: sync.WaitGroup{}, chanBuffer: config.chanBuffer, workers: config.workers}
 }
 

--- a/processor.go
+++ b/processor.go
@@ -44,18 +44,7 @@ var (
 )
 
 func NewLogProcessor(forwarder Forwarder, cache Cache, config appConfig) LogProcessor {
-	ql := prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: "upp",
-			Subsystem: "splunk_forwarder",
-			Name:      "queue_latency",
-			Help:      "Post queue latency",
-			Buckets:   []float64{.00001, .000015, .00002, .000025, .00003, .00004, .00005, .00006},
-		},
-		[]string{"environment"},
-	)
-	prometheus.Register(ql)
-	queueLatency = ql.With(prometheus.Labels{"environment": config.env})
+	queueLatency = registerHistogram("queue_latency", "Post queue latency", []float64{.00001, .000015, .00002, .000025, .00003, .00004, .00005, .00006})
 	return &logProcessor{forwarder: forwarder, cache: cache, wg: sync.WaitGroup{}, chanBuffer: config.chanBuffer, workers: config.workers}
 }
 

--- a/splunk.go
+++ b/splunk.go
@@ -12,10 +12,14 @@ import (
 	"strings"
 	"time"
 
+	prom "github.com/deathowl/go-metrics-prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"sync"
+
 	"github.com/cyberdelia/go-metrics-graphite"
 	"github.com/rcrowley/go-metrics"
 	"github.com/sirupsen/logrus"
-	"sync"
 )
 
 const (
@@ -111,6 +115,10 @@ func initMetrics(config appConfig) {
 
 	go metrics.Log(metrics.DefaultRegistry, 5*time.Second, log.New(os.Stdout, "metrics ", log.Lmicroseconds))
 	splunkMetrics()
+
+	prometheusRegistry := prometheus.NewRegistry()
+	pClient := prom.NewPrometheusProvider(metrics.DefaultRegistry, graphiteNamespace, "prom", prometheusRegistry, 5*time.Second)
+	go pClient.UpdatePrometheusMetrics()
 }
 
 func splunkMetrics() {

--- a/splunk.go
+++ b/splunk.go
@@ -63,10 +63,7 @@ func NewSplunkForwarder(config appConfig) Forwarder {
 
 func (splunk *splunkClient) forward(s string, callback func(string, error)) {
 	t := metrics.GetOrRegisterTimer("post.time", metrics.DefaultRegistry)
-	prometheusTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-		us := v * 1000000 // make microseconds
-		postTime.Observe(us)
-	}))
+	prometheusTimer := prometheus.NewTimer(postTime)
 	defer prometheusTimer.ObserveDuration()
 	t.Time(func() {
 		req, err := http.NewRequest("POST", splunk.config.fwdURL, strings.NewReader(s))

--- a/splunk.go
+++ b/splunk.go
@@ -175,7 +175,7 @@ func splunkMetrics() {
 			Subsystem: "splunk_forwarder",
 			Name:      "post_time",
 			Help:      "HTTP Post time",
-			Buckets:   []float64{.001, .002, .003, .0035, .004, .0045, .005, .006, .007, .008},
+			Buckets:   []float64{.002, .003, .0035, .004, .0045, .005, .006, .007, .008, .009},
 		},
 		[]string{"environment"},
 	)

--- a/splunk.go
+++ b/splunk.go
@@ -116,8 +116,7 @@ func initMetrics(config appConfig) {
 	go metrics.Log(metrics.DefaultRegistry, 5*time.Second, log.New(os.Stdout, "metrics ", log.Lmicroseconds))
 	splunkMetrics()
 
-	prometheusRegistry := prometheus.NewRegistry()
-	pClient := prom.NewPrometheusProvider(metrics.DefaultRegistry, graphiteNamespace, "prom", prometheusRegistry, 5*time.Second)
+	pClient := prom.NewPrometheusProvider(metrics.DefaultRegistry, graphiteNamespace, "prom", prometheus.DefaultRegisterer, 5*time.Second)
 	go pClient.UpdatePrometheusMetrics()
 }
 

--- a/splunk.go
+++ b/splunk.go
@@ -175,7 +175,7 @@ func splunkMetrics() {
 			Subsystem: "splunk_forwarder",
 			Name:      "post_time",
 			Help:      "HTTP Post time",
-			Buckets:   prometheus.DefBuckets,
+			Buckets:   []float64{.001, .002, .003, .0035, .004, .0045, .005, .006, .007, .008},
 		},
 		[]string{"environment"},
 	)

--- a/splunk.go
+++ b/splunk.go
@@ -116,7 +116,7 @@ func initMetrics(config appConfig) {
 	go metrics.Log(metrics.DefaultRegistry, 5*time.Second, log.New(os.Stdout, "metrics ", log.Lmicroseconds))
 	splunkMetrics()
 
-	pClient := prom.NewPrometheusProvider(metrics.DefaultRegistry, graphiteNamespace, "prom", prometheus.DefaultRegisterer, 5*time.Second)
+	pClient := prom.NewPrometheusProvider(metrics.DefaultRegistry, "upp", "resilient_splunk_forwarder", prometheus.DefaultRegisterer, 5*time.Second)
 	go pClient.UpdatePrometheusMetrics()
 }
 

--- a/splunk.go
+++ b/splunk.go
@@ -121,6 +121,7 @@ func initMetrics(config appConfig) {
 		logrus.Println(err)
 	}
 	go graphite.Graphite(metrics.DefaultRegistry, 5*time.Second, graphiteNamespace, addr)
+
 	go metrics.Log(metrics.DefaultRegistry, 5*time.Second, log.New(os.Stdout, "metrics ", log.Lmicroseconds))
 	splunkMetrics()
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -196,12 +196,6 @@
 			"revisionTime": "2017-07-13T16:51:06Z"
 		},
 		{
-			"checksumSHA1": "W/NHRhrNf43Esjr8cwxjkYSm8BA=",
-			"path": "github.com/deathowl/go-metrics-prometheus",
-			"revision": "091131e49c335a452af504b8104ac262da41a6e9",
-			"revisionTime": "2017-07-31T14:15:57Z"
-		},
-		{
 			"checksumSHA1": "XQhv3JgjCVPIV4MHmr/ZTiSkPp8=",
 			"origin": "github.com/aws/aws-sdk-go/vendor/github.com/go-ini/ini",
 			"path": "github.com/go-ini/ini",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -196,6 +196,12 @@
 			"revisionTime": "2017-07-13T16:51:06Z"
 		},
 		{
+			"checksumSHA1": "W/NHRhrNf43Esjr8cwxjkYSm8BA=",
+			"path": "github.com/deathowl/go-metrics-prometheus",
+			"revision": "091131e49c335a452af504b8104ac262da41a6e9",
+			"revisionTime": "2017-07-31T14:15:57Z"
+		},
+		{
 			"checksumSHA1": "XQhv3JgjCVPIV4MHmr/ZTiSkPp8=",
 			"origin": "github.com/aws/aws-sdk-go/vendor/github.com/go-ini/ini",
 			"path": "github.com/go-ini/ini",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,263 +3,359 @@
 	"ignore": "test",
 	"package": [
 		{
-			"checksumSHA1": "G8lW8pPVLieqh/MTJZkvI/i/WyM=",
+			"checksumSHA1": "UEJ0kpHhS/euvdF9nN2LIjZ7wS8=",
 			"path": "github.com/Financial-Times/go-fthealth/v1_1",
 			"revision": "1b007e2b37b7936dfb6671fa17e5a29fd35a08ea",
 			"revisionTime": "2017-12-04T12:48:31Z"
 		},
 		{
-			"checksumSHA1": "fqpohN7Qp2qj7TLMbUxh/cK4oH0=",
+			"checksumSHA1": "lQfsRf7gWYQDNoI3IOZuwNGUwRo=",
 			"path": "github.com/Financial-Times/service-status-go/buildinfo",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "2rGNLXdRC3qr5n5ll7BpYt8HCK8=",
+			"checksumSHA1": "7QAsTdXi/6nTkDhqKy54YIc69d4=",
 			"path": "github.com/Financial-Times/service-status-go/gtg",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "973POGyMCoyaKQuIYX2f7EKFwlQ=",
+			"checksumSHA1": "YxgjuCI4TJyfQujUeQk3V+gypzo=",
 			"path": "github.com/Financial-Times/service-status-go/httphandlers",
 			"revision": "3f5199736a3d7ae52394c63aac36834786825e21",
 			"revisionTime": "2016-03-23T11:15:42Z"
 		},
 		{
-			"checksumSHA1": "1yWi/sgzK+3VyPnv2wDDr6F8obs=",
+			"checksumSHA1": "uFW7tgWH0wZYX/HKFNR5mlSlgAs=",
 			"path": "github.com/aws/aws-sdk-go/aws",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
+			"checksumSHA1": "t6ccluqwYvYUbu7QKXlOrMdpuh0=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
+			"checksumSHA1": "Lx0NeH8jhZL7zy6lNqRyog7dfTQ=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "slpNCdnZ2JbBr94ZHc/9UzOaP5A=",
+			"checksumSHA1": "PKm6RXv7Ee15v2i4/n6YOVfcTLk=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
+			"checksumSHA1": "XpRY3N6+DWRS0JJA2npr8x6YgBI=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
+			"checksumSHA1": "T6LwCC0Qoq7wm5DiqWG+oznGer8=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "Y+cPwQL0dZMyqp3wI+KJWmA9KQ8=",
+			"checksumSHA1": "Zy7DsNJuZ7z6AnPQHDElDG17+VA=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
+			"checksumSHA1": "UnVL+i6fHI5yRAMxu8K/uRFH9uU=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
+			"checksumSHA1": "oXukD2QzsNVvDDT0hhqD5JDkh60=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
+			"checksumSHA1": "AGOxW4xDNNX9bu/KtziSH9U5Ee8=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "ZdtYh3ZHSgP/WEIaqwJHTEhpkbs=",
+			"checksumSHA1": "yoG0+XODzdUJVYXXncOo5PLir6c=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
+			"checksumSHA1": "pi+FyO/XW62v3joQeK+8Xqw1VqQ=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "vVKUiiZzOwre3zlHIGcjFgjjR68=",
+			"checksumSHA1": "wJk16a6W10mVo8vsYF50ByiKTPY=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "OB2foQOM27puEGoW4+bM/K2KR5g=",
+			"checksumSHA1": "Qf3ZNC77NPshWm7abtgGdfXiWqc=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "HcGL4e6Uep4/80eCUI5xkcWjpQ0=",
+			"checksumSHA1": "dZ+DGH+eSn9CkUrzymLMC0Sik3w=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "yzP2WtJtlWQ07Yxlb8NUJREAUEU=",
+			"checksumSHA1": "urOo/s7l06IJByfx2bj1CpCSqT8=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "04ypv4x12l4q0TksA1zEVsmgpvw=",
+			"checksumSHA1": "hvzGtLIl1xSh1hdo30OteYyAKu0=",
 			"path": "github.com/aws/aws-sdk-go/internal/shareddefaults",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
+			"checksumSHA1": "Yqzg8E+wX+Xu9Xcv9XieKntmjkA=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
+			"checksumSHA1": "IjdtzOd+iq+uqoPhIVCdzG5NHXw=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "9V1PvtFQ9MObZTc3sa86WcuOtOU=",
+			"checksumSHA1": "VLIL5R+czfbyTIPzNoOzfp++Mwo=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
+			"checksumSHA1": "1RC9QKWnhxY1N94f9IU3lYLz57s=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
+			"checksumSHA1": "Mfy8JznRGtNWJkxyw4PCRccdZKA=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
+			"checksumSHA1": "eFxTRe1VUzuRFUa157HbdkvXKWI=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "ZjWHq0sDldcDC+Zd/ZIBy5Oj3hI=",
+			"checksumSHA1": "A0ffiM5wO/sMCDyoTtY7HWL+PC8=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "d9vR1rl8kmJxJBwe00byziVFR/o=",
+			"checksumSHA1": "3lk2c85HmCDW1d8Q79icotUpnbo=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "/6H1rhQmbq8mEP29pnmLmdwBKUE=",
+			"checksumSHA1": "drpRPs82SbbV6FBNxoGVGpjEe/Q=",
+			"path": "github.com/beorn7/perks/quantile",
+			"revision": "3a771d992973f24aa725d07868b467d1ddfceafb",
+			"revisionTime": "2018-03-21T16:47:47Z"
+		},
+		{
+			"checksumSHA1": "guo63XdLn1n7MtawdVcICjFNNBI=",
 			"path": "github.com/cyberdelia/go-metrics-graphite",
 			"revision": "39f87cc3b432bbb898d7c643c0e93cac2bc865ad",
 			"revisionTime": "2016-12-19T23:08:53Z"
 		},
 		{
-			"checksumSHA1": "OFu4xJEIjiI8Suu+j/gabfp+y6Q=",
+			"checksumSHA1": "DuEyF75v9xaKXfJsCPRdHNOpGZk=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/davecgh/go-spew/spew",
 			"path": "github.com/davecgh/go-spew/spew",
 			"revision": "05e8a0eda380579888eb53c394909df027f06991",
 			"revisionTime": "2017-07-13T16:51:06Z"
 		},
 		{
-			"checksumSHA1": "VvZKmbuBN1QAG699KduTdmSPwA4=",
+			"checksumSHA1": "XQhv3JgjCVPIV4MHmr/ZTiSkPp8=",
 			"origin": "github.com/aws/aws-sdk-go/vendor/github.com/go-ini/ini",
 			"path": "github.com/go-ini/ini",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "tUGxc7rfX0cmhOOUDhMuAZ9rWsA=",
+			"checksumSHA1": "jnSBctrtbfjyZCnEY0bHW5JGW5s=",
+			"path": "github.com/gogo/protobuf/proto",
+			"revision": "5669497fd64452f28d142899eeb1bfd7e8b26ac8",
+			"revisionTime": "2018-08-30T16:04:56Z"
+		},
+		{
+			"checksumSHA1": "0j/uJco81D4dxdFhL2BBusXndZE=",
+			"path": "github.com/golang/protobuf/proto",
+			"revision": "e344474228f55cc8e5f2342b0493b71bcdd258f4",
+			"revisionTime": "2018-09-10T22:49:16Z"
+		},
+		{
+			"checksumSHA1": "KJqRW8jfPoHquMAd6FI7x92JxFs=",
 			"path": "github.com/hashicorp/go-version",
 			"revision": "03c5bf6be031b6dd45afec16b1cf94fc8938bc77",
 			"revisionTime": "2017-02-02T08:07:59Z"
 		},
 		{
-			"checksumSHA1": "NK3DaezXmT5QyDImKH+qqI2Xa7c=",
+			"checksumSHA1": "CRYmanmmriS4QPTxS4mM9KhcZI0=",
 			"path": "github.com/jawher/mow.cli",
 			"revision": "8327d12beb75e6471b7f045588acc318d1147146",
 			"revisionTime": "2017-04-30T13:52:12Z"
 		},
 		{
-			"checksumSHA1": "0ZrwvB6KoGPj2PoDNSEJwxQ6Mog=",
+			"checksumSHA1": "Wbsfxh89xfnFDZzoEOzpfUV9+u8=",
 			"origin": "github.com/aws/aws-sdk-go/vendor/github.com/jmespath/go-jmespath",
 			"path": "github.com/jmespath/go-jmespath",
 			"revision": "395e6c4c7c39301826d2cab2451567c8c86a1253",
 			"revisionTime": "2017-11-13T23:54:33Z"
 		},
 		{
-			"checksumSHA1": "Se195FlZ160eaEk/uVx4KdTPSxU=",
+			"checksumSHA1": "bQ9BML+wAZd81vdDAOC1U+yN8dU=",
+			"path": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+			"revision": "c12348ce28de40eed0136aa2b644d0ee0650e56c",
+			"revisionTime": "2016-04-24T11:30:07Z"
+		},
+		{
+			"checksumSHA1": "eVoyhpCbyPg6D3P63EStHNO6iIQ=",
 			"path": "github.com/pborman/uuid",
 			"revision": "e790cca94e6cc75c7064b1332e63811d4aae1a53",
 			"revisionTime": "2017-06-12T15:36:48Z"
 		},
 		{
-			"checksumSHA1": "ljd3FhYRJ91cLZz3wsH9BQQ2JbA=",
+			"checksumSHA1": "d6BycwPpKXW09I/tXMqcItE8SA4=",
 			"path": "github.com/pkg/errors",
 			"revision": "30136e27e2ac8d167177e8a583aa4c3fea5be833",
 			"revisionTime": "2018-01-27T01:58:12Z"
 		},
 		{
-			"checksumSHA1": "zKKp5SZ3d3ycKe4EKMNT0BqAWBw=",
+			"checksumSHA1": "+oyIJwPyeof36XCkY8awrNfxaNM=",
 			"origin": "github.com/stretchr/testify/vendor/github.com/pmezard/go-difflib/difflib",
 			"path": "github.com/pmezard/go-difflib/difflib",
 			"revision": "05e8a0eda380579888eb53c394909df027f06991",
 			"revisionTime": "2017-07-13T16:51:06Z"
 		},
 		{
-			"checksumSHA1": "KAzbLjI9MzW2tjfcAsK75lVRp6I=",
+			"checksumSHA1": "+T4Ev2zYTm2pRdqegeO9ZI5MLbc=",
+			"path": "github.com/prometheus/client_golang",
+			"revision": "7858729281ec582767b20e0d696b6041d995d5e0",
+			"revisionTime": "2018-09-07T10:25:42Z"
+		},
+		{
+			"checksumSHA1": "PtBCNubWaNhZWTPWHcy1RTZw5J4=",
+			"path": "github.com/prometheus/client_golang/prometheus",
+			"revision": "7858729281ec582767b20e0d696b6041d995d5e0",
+			"revisionTime": "2018-09-07T10:25:42Z"
+		},
+		{
+			"checksumSHA1": "sQNOtUGbHwzg79Sxa2ep4vYk3ck=",
+			"path": "github.com/prometheus/client_golang/prometheus/internal",
+			"revision": "7858729281ec582767b20e0d696b6041d995d5e0",
+			"revisionTime": "2018-09-07T10:25:42Z"
+		},
+		{
+			"checksumSHA1": "7Dcx0WzbbAOO78emnSce+Ia+938=",
+			"path": "github.com/prometheus/client_golang/prometheus/promhttp",
+			"revision": "7858729281ec582767b20e0d696b6041d995d5e0",
+			"revisionTime": "2018-09-07T10:25:42Z"
+		},
+		{
+			"checksumSHA1": "807PkeEjnsPQfo7J98Pk+xjYst4=",
+			"path": "github.com/prometheus/client_model/go",
+			"revision": "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f",
+			"revisionTime": "2018-07-12T10:51:10Z"
+		},
+		{
+			"checksumSHA1": "pSPZnM4m1dezfOvSHASZi5LqOLs=",
+			"path": "github.com/prometheus/common/expfmt",
+			"revision": "c7de2306084e37d54b8be01f3541a8464345e9a5",
+			"revisionTime": "2018-08-01T06:44:54Z"
+		},
+		{
+			"checksumSHA1": "5ZLUh5QIuJSJZJvrdWajRGiqY1E=",
+			"path": "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
+			"revision": "c7de2306084e37d54b8be01f3541a8464345e9a5",
+			"revisionTime": "2018-08-01T06:44:54Z"
+		},
+		{
+			"checksumSHA1": "+Mpwd2jU4IVDlnS2VBICgw1xZY4=",
+			"path": "github.com/prometheus/common/model",
+			"revision": "c7de2306084e37d54b8be01f3541a8464345e9a5",
+			"revisionTime": "2018-08-01T06:44:54Z"
+		},
+		{
+			"checksumSHA1": "RcPquDqPXmsS1ULxW2Dczegyejk=",
+			"path": "github.com/prometheus/procfs",
+			"revision": "05ee40e3a273f7245e8777337fc7b46e533a9a92",
+			"revisionTime": "2018-07-25T12:39:19Z"
+		},
+		{
+			"checksumSHA1": "x3ZiuMEGp4vFxek+H5xWCxFwjSc=",
+			"path": "github.com/prometheus/procfs/internal/util",
+			"revision": "05ee40e3a273f7245e8777337fc7b46e533a9a92",
+			"revisionTime": "2018-07-25T12:39:19Z"
+		},
+		{
+			"checksumSHA1": "ojboKIxsT2Ww55AF6QZP07Jjt0I=",
+			"path": "github.com/prometheus/procfs/nfs",
+			"revision": "05ee40e3a273f7245e8777337fc7b46e533a9a92",
+			"revisionTime": "2018-07-25T12:39:19Z"
+		},
+		{
+			"checksumSHA1": "bTwvKCBzu1V/86hLb8mvzkl8j3s=",
+			"path": "github.com/prometheus/procfs/xfs",
+			"revision": "05ee40e3a273f7245e8777337fc7b46e533a9a92",
+			"revisionTime": "2018-07-25T12:39:19Z"
+		},
+		{
+			"checksumSHA1": "DIjooF5+DLH5JSOjqnBlfNh9dFU=",
 			"path": "github.com/rcrowley/go-metrics",
 			"revision": "1f30fe9094a513ce4c700b9a54458bbb0c96996c",
 			"revisionTime": "2016-11-28T21:05:44Z"
 		},
 		{
-			"checksumSHA1": "lpLPku3Jj2lwjDNCDSzPq6fqEuU=",
+			"checksumSHA1": "RQn2haYRhM4g31hN8+pVopABTbI=",
 			"path": "github.com/sirupsen/logrus",
 			"revision": "5b60b3d3ee017ed00bcd0225fcca7acab767844b",
 			"revisionTime": "2017-05-04T07:10:19Z"
 		},
 		{
-			"checksumSHA1": "6thzskcj6XrMO5kW6GlRiuTDYjU=",
+			"checksumSHA1": "+IkucM/8+JlB9p9Ezp55ftFLo6w=",
 			"path": "github.com/stretchr/objx",
 			"revision": "8a3f7159479fbc75b30357fbc48f380b7320f08e",
 			"revisionTime": "2018-01-29T17:20:03Z"
 		},
 		{
-			"checksumSHA1": "J+ppEq6nYMKxhB9+c+MD1x9UwSc=",
+			"checksumSHA1": "apnct41Aty4SaqWD4RLc7bxVF0w=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "05e8a0eda380579888eb53c394909df027f06991",
 			"revisionTime": "2017-07-13T16:51:06Z"
 		},
 		{
-			"checksumSHA1": "ktEYN4KC8f/rdhtfVslmtcKaX8E=",
+			"checksumSHA1": "xMbCPt96HOc9sMNaZuJ8pMwWRoI=",
 			"path": "github.com/stretchr/testify/mock",
 			"revision": "be8372ae8ec5c6daaed3cc28ebf73c54b737c240",
 			"revisionTime": "2018-02-02T15:35:43Z"


### PR DESCRIPTION
- used the prometheus go client to generate count and histogram metrics, which Prometheus will read from the newly-exposed `/metrics` endpoint
- the request timers wrap the go-metrics timers so they may be a bit inaccurate - this will be fixed after we remove go-metrics
- the `ServiceMonitor` component tells Prometheus that it should scrape our `metrics` endpoint for metrics
