### PR TITLE
Switch to 1.x.x version of golang orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  golang-ci: financial-times/golang-ci@1.0.0
+  golang-ci: financial-times/golang-ci@1
 
 workflows:
   tests_and_docker:


### PR DESCRIPTION
Change version of the golang orb such that all new feature updates and fixes will be pulled.