### PR TITLE
Make the service's logs less verbose

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -91,7 +91,7 @@ func (logProcessor *logProcessor) Start() {
 			for msg := range logProcessor.inChan {
 				err := logProcessor.cache.Put(msg)
 				if err != nil {
-					logProcessor.uppLogger.Infof("Unexpected error when caching messages: %v\n", err)
+					logProcessor.uppLogger.Errorf("Unexpected error when caching messages: %v\n", err)
 				}
 			}
 		}()
@@ -103,9 +103,9 @@ func (logProcessor *logProcessor) Start() {
 		for !logProcessor.isStopped() {
 			entries, err := logProcessor.Dequeue()
 			if err != nil {
-				logProcessor.uppLogger.Infof("Failure retrieving logs from S3 %v\n", err)
+				logProcessor.uppLogger.Errorf("Failure retrieving logs from S3 %v\n", err)
 			} else if len(entries) > 0 {
-				logProcessor.uppLogger.Infof("Read %v messages from S3\n", len(entries))
+				logProcessor.uppLogger.Debugf("Read %v messages from S3\n", len(entries))
 			}
 			for _, entry := range entries {
 				mutex.Lock()
@@ -124,7 +124,7 @@ func (logProcessor *logProcessor) Start() {
 					logProcessor.uppLogger.Infof("Sleeping for %v\n", sleepDuration)
 					time.Sleep(sleepDuration)
 				}
-				logProcessor.uppLogger.Infof("Sending document to channel")
+				logProcessor.uppLogger.Debug("Sending document to channel")
 				prometheusTimer := prometheus.NewTimer(queueLatency)
 				logProcessor.outChan <- entry
 				prometheusTimer.ObserveDuration()


### PR DESCRIPTION
# Description

- Use different log levels where approriate instead of `Info` everywhere.
- Change the two most common log statements from Info to Debug to reduce the amount of logs and make the other logs easier to spot.

## Why

On 29.12.2022 **UPP Prod - NO MongoDB Hot Backup** Splunk alert was [triggered](https://financialtimes.slack.com/archives/C0X82QPLN/p1672322455138959). After a quick investigation it turned out that the `mongo-hot-backup` service was working as expected and there were more logs on the cluster than in Splunk for the service. 

We don't store the logs from `resilient-splunk-forwarder` in Splunk and the service logs too much - on the cluster we store logs for the past several hours, after that they get wiped. 

The aim of this PR is to reduce the amount of logging so that we can check if something went wrong if we found missing logs from Splunk again.

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Breaking change
- [x] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
